### PR TITLE
Fixes NameError related to Pathname

### DIFF
--- a/lib/exiftool.rb
+++ b/lib/exiftool.rb
@@ -4,6 +4,7 @@ require 'json'
 require 'shellwords'
 require 'exiftool/result'
 require 'forwardable'
+require 'pathname'
 
 # Exiftool Class
 class Exiftool


### PR DESCRIPTION
Fixes exiftool.rb:49:in `initialize': uninitialized constant Exiftool::Pathname (NameError) when multiget is used.

Error happens when user follows documentation and tries to use multiget like `e = Exiftool.new(Dir["**/*.jpg"])` as Pathname is undefined in line 49.