### PR TITLE
Suppress for `Gemspec/DevelopmentDependencies` offense

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,9 @@ AllCops:
   TargetRubyVersion: 2.7
   NewCops: enable
 
+Gemspec/DevelopmentDependencies:
+  EnforcedStyle: gemspec
+
 Style/SpecialGlobalVars:
   EnforcedStyle: use_perl_names
 


### PR DESCRIPTION
This PR suppress for `Gemspec/DevelopmentDependencies` offense.

```
❯ bundle exec rubocop
Inspecting 10 files
..C.......

Offenses:

exiftool.gemspec:27:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  spec.add_development_dependency 'bundler'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
exiftool.gemspec:28:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  spec.add_development_dependency 'minitest'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
exiftool.gemspec:29:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  spec.add_development_dependency 'minitest-great_expectations'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
exiftool.gemspec:30:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  spec.add_development_dependency 'minitest-reporters' unless ENV['CI']
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
exiftool.gemspec:31:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  spec.add_development_dependency 'rake'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
exiftool.gemspec:32:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  spec.add_development_dependency 'rubocop'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
exiftool.gemspec:33:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  spec.add_development_dependency 'rubocop-minitest'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
exiftool.gemspec:34:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  spec.add_development_dependency 'rubocop-rake'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
exiftool.gemspec:35:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  spec.add_development_dependency 'simplecov'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
exiftool.gemspec:36:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  spec.add_development_dependency 'simplecov-console'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
exiftool.gemspec:37:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  spec.add_development_dependency 'simplecov_json_formatter'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
exiftool.gemspec:38:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  spec.add_development_dependency 'yard'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

10 files inspected, 12 offenses detected
```