### PR TITLE
fixing track tags fractions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,10 @@ jobs:
       - name: Run tests
         run: bundle exec rake
       - name: Test & publish code coverage
-        uses: paambaati/codeclimate-action@v9.0.0
-        env:
-          CC_TEST_REPORTER_ID: 27df0a8ad648d4af0f931c1b0101cca2278fcfd755112b4d563650c45f48071c
+        uses: qltysh/qlty-action/coverage@v2
+        with:
+          token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
+          files: coverage/.resultset.json
+        # uses: paambaati/codeclimate-action@v9.0.0
+        # env:
+        #   CC_TEST_REPORTER_ID: 27df0a8ad648d4af0f931c1b0101cca2278fcfd755112b4d563650c45f48071c

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![Gem Version](https://badge.fury.io/rb/exiftool.svg)](http://rubygems.org/gems/exiftool)
 [![Gem Downloads](https://img.shields.io/gem/dt/exiftool.svg)](http://rubygems.org/gems/exiftool)
 [![Gem Latest](https://img.shields.io/gem/dtv/exiftool.svg)](http://rubygems.org/gems/exiftool)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/82cfb3b0d0d5e67499c7/test_coverage)](https://codeclimate.com/github/exiftool-rb/exiftool.rb/test_coverage)
-[![Maintainability](https://api.codeclimate.com/v1/badges/82cfb3b0d0d5e67499c7/maintainability)](https://codeclimate.com/github/exiftool-rb/exiftool.rb/maintainability)
+[![Code Coverage](https://qlty.sh/gh/exiftool-rb/projects/exiftool/coverage.svg)](https://qlty.sh/gh/exiftool-rb/projects/exiftool)
+[![Maintainability](https://qlty.sh/gh/exiftool-rb/projects/exiftool/maintainability.svg)](https://qlty.sh/gh/exiftool-rb/projects/exiftool)
 
 This gem is the simplest thing that could possibly work that
 reads the output of [exiftool](http://www.sno.phy.queensu.ca/~phil/exiftool)

--- a/lib/exiftool/field_parser.rb
+++ b/lib/exiftool/field_parser.rb
@@ -81,7 +81,7 @@ class Exiftool
     end
 
     def fraction?
-      raw_value.is_a?(String) && raw_value =~ FRACTION_RE
+      raw_value.is_a?(String) && raw_value =~ FRACTION_RE && sym_key != :track
     end
 
     def as_fraction

--- a/test/field_parser_test.rb
+++ b/test/field_parser_test.rb
@@ -98,4 +98,9 @@ describe Exiftool::FieldParser do
     p = Exiftool::FieldParser.new('GPSLongitude', -122.475666666667)
     _(p.value).must_be_close_to(-122.475666666667)
   end
+
+  it 'parses track tags without reducing a fraction to lowest terms' do
+    p = Exiftool::FieldParser.new('Track', '2/24')
+    _(p.value).must_equal('2/24')
+  end
 end


### PR DESCRIPTION
fixing https://github.com/exiftool-rb/exiftool_vendored.rb/issues/37 issue where track tags were treated as fractions and were reduced to the lowest term in the output.