### PR TITLE
Add support for StringIO input in Exiftool

### DIFF
--- a/lib/exiftool.rb
+++ b/lib/exiftool.rb
@@ -6,6 +6,7 @@ require 'open3'
 require 'exiftool/result'
 require 'forwardable'
 require 'pathname'
+require 'stringio'
 
 # Exiftool Class
 class Exiftool
@@ -62,7 +63,7 @@ class Exiftool
   def initialize(filenames, exiftool_opts = '')
     @file2result = {}
     io_input = nil
-    if filenames.is_a?(IO)
+    if filenames.is_a?(IO) || filenames.is_a?(StringIO)
       io_input = filenames
       filenames = ['-']
     end

--- a/test/exiftool_test.rb
+++ b/test/exiftool_test.rb
@@ -91,6 +91,16 @@ describe Exiftool do
     end
   end
 
+  it 'supports a StringIO object as a constructor arg' do
+    io = StringIO.new(File.binread('test/IMG_2452.jpg'))
+    e = Exiftool.new(io)
+    _(e.errors?).must_be_false
+    h = e.to_hash
+    _(h[:file_type]).must_equal 'JPEG'
+    _(h[:mime_type]).must_equal 'image/jpeg'
+    _(h[:make]).must_equal 'Canon'
+  end
+
   describe 'single-get' do
     it 'responds with known correct responses' do
       Dir['test/*.jpg'].each do |filename|


### PR DESCRIPTION
StringIO doesn't inherit IO, so it needs to be checked explicitly