### PR TITLE
Locking Minitest while sorting out a permanent fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 
 group :development do
   gem 'bundler'
-  gem 'minitest'
+  gem 'minitest', '5.26.0'
   gem 'minitest-great_expectations'
   gem 'minitest-reporters' unless ENV['CI']
   gem 'rake'


### PR DESCRIPTION
Locking minitest to version  '5.26.0' until permanent fix compatible with current versions is found.