### PR TITLE
Maintenance, test and dev dependencies update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.2', '3.3', '3.4']
+        ruby-version: ['3.2', '3.3', '3.4', '4.0']
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.1', '3.2', '3.3', '3.4']
+        ruby-version: ['3.2', '3.3', '3.4']
 
     steps:
       - uses: actions/checkout@v6

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ plugins:
   - rubocop-rake
 
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
   NewCops: enable
 
 Style/SpecialGlobalVars:

--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,7 @@ gemspec
 
 group :development do
   gem 'bundler'
-  gem 'minitest', '5.26.0'
-  gem 'minitest-great_expectations'
+  gem 'minitest'
   gem 'minitest-reporters' unless ENV['CI']
   gem 'rake'
   gem 'rubocop'

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This gem is the simplest thing that could possibly work that
 reads the output of [exiftool](http://www.sno.phy.queensu.ca/~phil/exiftool)
 and renders it into a ruby hash, with _correctly typed values_ and symbolized keys.
 
-Ruby 3.1 through 3.3 are supported.
+Ruby 3.2 through 3.4 are supported.
 
 ## Ruby Support Deprecation Notice
 
@@ -23,6 +23,7 @@ Ruby Versions due to their [End Of Life](https://www.ruby-lang.org/en/downloads/
 - Ruby 2.6 (EOL 2022-04-12)
 - Ruby 2.7 (EOL 2023-03-31)
 - Ruby 3.0 (EOL 2024-04-23)
+- Ruby 3.1 (EOL 2025-03-26)
 
 The latest Exiftool is recommended, but you'll get that automatically by using the
 [exiftool_vendored](https://github.com/exiftool-rb/exiftool_vendored.rb) gem!

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This gem is the simplest thing that could possibly work that
 reads the output of [exiftool](http://www.sno.phy.queensu.ca/~phil/exiftool)
 and renders it into a ruby hash, with _correctly typed values_ and symbolized keys.
 
-Ruby 3.2 through 3.4 are supported.
+Ruby 3.2 through 4.0 are supported.
 
 ## Ruby Support Deprecation Notice
 

--- a/exiftool.gemspec
+++ b/exiftool.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 
-  spec.required_ruby_version = '>= 3.1'
+  spec.required_ruby_version = '>= 3.2'
 
   spec.files         = `git ls-files -- lib`.split($/)
   spec.require_paths = %w[lib]

--- a/test/exiftool_test.rb
+++ b/test/exiftool_test.rb
@@ -34,46 +34,50 @@ IGNORABLE_PATTERNS = [
 
 describe Exiftool do
   it 'returns a sensible version' do
-    _(Exiftool.exiftool_version).must_match(/\A\d+\.\d+\z/)
+    assert_match(/\A\d+\.\d+\z/, Exiftool.exiftool_version)
   end
 
   it 'returns true for exiftool installed' do
-    _(Exiftool.exiftool_installed?).must_be_true
+    assert_predicate(Exiftool, :exiftool_installed?)
   end
 
   it 'sets custom path for exiftool' do
     e = Exiftool.dup
     e.command = 'foo/bar/exiftool'
 
-    _(e.command).must_match('foo/bar/exiftool')
+    assert_equal('foo/bar/exiftool', e.command)
   end
 
   it 'raises NoSuchFile for missing files' do
-    _ { Exiftool.new('no/such/file') }.must_raise Exiftool::NoSuchFile
+    assert_raises(Exiftool::NoSuchFile) { Exiftool.new('no/such/file') }
   end
 
   it 'raises NotAFile for directories' do
-    _ { Exiftool.new('lib') }.must_raise Exiftool::NotAFile
+    assert_raises(Exiftool::NotAFile) { Exiftool.new('lib') }
   end
 
   it 'no-ops with no files' do
     e = Exiftool.new([])
-    _(e.errors?).must_be_false
+
+    refute_predicate(e, :errors?)
   end
 
   it 'has errors with files without EXIF headers' do
     e = Exiftool.new('test/binary_file')
-    _(e.errors?).must_be_true
+
+    assert_predicate(e, :errors?)
   end
 
   it 'returns results with error when explicitly asked' do
     e = Exiftool.new('test/binary_file')
-    _(e.results(include_results_with_errors: true).any?).must_be_true
+
+    assert_predicate(e.results(include_results_with_errors: true), :any?)
   end
 
   it 'doesn\'t return results with errors' do
     e = Exiftool.new('test/binary_file')
-    _(e.results.any?).must_be_false
+
+    refute_predicate(e.results, :any?)
   end
 
   it 'supports a singular Pathname as a constructor arg' do
@@ -84,24 +88,26 @@ describe Exiftool do
   it 'supports an IO object as a constructor arg' do
     File.open('test/IMG_2452.jpg', 'rb') do |io|
       e = Exiftool.new(io)
-      _(e.errors?).must_be_false
       h = e.to_hash
 
-      _(h[:file_type]).must_equal 'JPEG'
-      _(h[:mime_type]).must_equal 'image/jpeg'
-      _(h[:make]).must_equal 'Canon'
+      refute_predicate(e, :errors?)
+      assert_equal(
+        { file_type: 'JPEG', mime_type: 'image/jpeg', make: 'Canon' },
+        h.slice(:file_type, :mime_type, :make)
+      )
     end
   end
 
   it 'supports a StringIO object as a constructor arg' do
     io = StringIO.new(File.binread('test/IMG_2452.jpg'))
     e = Exiftool.new(io)
-    _(e.errors?).must_be_false
     h = e.to_hash
 
-    _(h[:file_type]).must_equal 'JPEG'
-    _(h[:mime_type]).must_equal 'image/jpeg'
-    _(h[:make]).must_equal 'Canon'
+    refute_predicate(e, :errors?)
+    assert_equal(
+      { file_type: 'JPEG', mime_type: 'image/jpeg', make: 'Canon' },
+      h.slice(:file_type, :mime_type, :make)
+    )
   end
 
   describe 'single-get' do
@@ -109,13 +115,13 @@ describe Exiftool do
       Dir['test/*.jpg'].each do |filename|
         e = Exiftool.new(filename)
 
-        _(e[:source_file]).must_equal Exiftool.expand_path(filename)
+        assert_equal(Exiftool.expand_path(filename), e[:source_file])
         validate_result(e, filename)
       end
       Dir['test/*.tif'].each do |filename|
         e = Exiftool.new(filename)
 
-        _(e[:source_file]).must_equal Exiftool.expand_path(filename)
+        assert_equal(Exiftool.expand_path(filename), e[:source_file])
         validate_result(e, filename)
       end
     end
@@ -123,9 +129,9 @@ describe Exiftool do
     it 'fails if there are multiple files provided and Exiftool is treated as a result' do
       e = Exiftool.new(Dir['test/*.jpg'])
 
-      _ { e.to_hash[:source_file] }.must_raise Exiftool::NoDefaultResultWithMultiget
-      _ { e[:source_file] }.must_raise Exiftool::NoDefaultResultWithMultiget
-      _ { e.raw[:aperture] }.must_raise Exiftool::NoDefaultResultWithMultiget
+      assert_raises(Exiftool::NoDefaultResultWithMultiget) { e.to_hash[:source_file] }
+      assert_raises(Exiftool::NoDefaultResultWithMultiget) { e[:source_file] }
+      assert_raises(Exiftool::NoDefaultResultWithMultiget) { e.raw[:aperture] }
     end
   end
 
@@ -140,7 +146,7 @@ describe Exiftool do
       filenames = Dir['**/*.jpg'].to_a
       e = Exiftool.new(filenames)
 
-      _(e.files_with_results.size).must_equal(6)
+      assert_equal(6, e.files_with_results.size)
     end
   end
 
@@ -151,7 +157,8 @@ describe Exiftool do
     File.open(yaml_file, 'w') { |out| YAML.dump(actual, out) } if ENV['DUMP_RESULTS']
     expected = File.open(yaml_file) { |f| YAML.safe_load(f, permitted_classes: [Symbol, Date, Rational]) }
     expected.delete_if { |k, _v| ignorable_key?(k) }
-    _(actual).must_equal_hash(expected)
+
+    assert_equal(expected, actual)
   end
 
   puts "Ignoring #{IGNORABLE_KEYS.size} keys."

--- a/test/field_parser_test.rb
+++ b/test/field_parser_test.rb
@@ -6,121 +6,121 @@ describe Exiftool::FieldParser do
   it 'creates snake-case symbolic keys properly' do
     p = Exiftool::FieldParser.new('HyperfocalDistance', '')
 
-    _(p.sym_key).must_equal(:hyperfocal_distance)
+    assert_equal(:hyperfocal_distance, p.sym_key)
   end
 
   it 'creates display keys properly' do
     p = Exiftool::FieldParser.new('InternalSerialNumber', '')
 
-    _(p.display_key).must_equal('Internal Serial Number')
+    assert_equal('Internal Serial Number', p.display_key)
   end
 
   it 'parses date flags without warnings' do
     p = Exiftool::FieldParser.new('DateStampMode', 'Off')
 
-    _(p.value).must_equal('Off')
+    assert_equal('Off', p.value)
   end
 
   it 'leaves dates without timezones as strings' do
     p = Exiftool::FieldParser.new('CreateDate', '2004:09:19 12:25:20')
 
-    _(p.value).must_equal('2004:09:19 12:25:20')
+    assert_equal('2004:09:19 12:25:20', p.value)
   end
 
   it 'extracts YMD from timestamps' do
     p = Exiftool::FieldParser.new('DateTimeOriginal', '2004:09:19 12:25:20')
 
-    _(p.civil_date).must_equal(Date.civil(2004, 9, 19))
+    assert_equal(Date.civil(2004, 9, 19), p.civil_date)
   end
 
   it 'ignores "zero-date" YMD timestamps' do
     p = Exiftool::FieldParser.new('DateTimeOriginal', '0000:00:00 00:00:00')
 
-    _(p.civil_date).must_be_nil
+    assert_nil(p.civil_date)
   end
 
   it 'ignores "zero-date" YMD dates' do
     p = Exiftool::FieldParser.new('DateTimeOriginal', '0000:00:00')
 
-    _(p.civil_date).must_be_nil
+    assert_nil(p.civil_date)
   end
 
   it 'skips invalid dates' do
     p = Exiftool::FieldParser.new('GPSDateTime', '0111:00:30 20:31:58Z')
 
-    _(p.value).must_equal('0111:00:30 20:31:58Z')
-    _(p.civil_date).must_be_nil
+    assert_equal('0111:00:30 20:31:58Z', p.value)
+    assert_nil(p.civil_date)
   end
 
   it 'returns nil for YMD for date flags' do
     p = Exiftool::FieldParser.new('DateStampMode', 'Off')
 
-    _(p.civil_date).must_be_nil
+    assert_nil(p.civil_date)
   end
 
   it 'parses sub-second times' do
     p = Exiftool::FieldParser.new('SubSecDateTimeOriginal', '2011:09:25 20:08:09.234-08:00')
 
-    _(p.value).must_equal(Time.parse('2011-09-25 20:08:09.234-08:00'))
+    assert_equal(Time.parse('2011-09-25 20:08:09.234-08:00'), p.value)
   end
 
   it 'parses dates with timezones' do
     p = Exiftool::FieldParser.new('FileAccessDate', '2013:07:14 10:50:33-07:00')
 
-    _(p.value).must_equal(Time.parse('2013-07-14 10:50:33-07:00'))
+    assert_equal(Time.parse('2013-07-14 10:50:33-07:00'), p.value)
   end
 
   it 'parses date-times with only zeroes' do
     p = Exiftool::FieldParser.new('MediaCreateDate', '0000:00:00 00:00:00')
 
-    _(p.value).must_equal('0000:00:00 00:00:00')
+    assert_equal('0000:00:00 00:00:00', p.value)
   end
 
   it 'parses dates with only zeroes' do
     p = Exiftool::FieldParser.new('ModifyDate', '0000:00:00')
 
-    _(p.value).must_equal('0000:00:00')
+    assert_equal('0000:00:00', p.value)
   end
 
   it 'parses fractions properly' do
     p = Exiftool::FieldParser.new('ShutterSpeedValue', '1/6135')
 
-    _(p.value).must_equal(Rational(1, 6135))
+    assert_equal(Rational(1, 6135), p.value)
   end
 
   it 'parses N GPS coords' do
     p = Exiftool::FieldParser.new('GPSLatitude', '37.50233333 N')
 
-    _(p.value).must_be_close_to(37.50233333)
+    assert_in_delta(37.50233333, p.value)
   end
 
   it 'parses S GPS coords' do
     p = Exiftool::FieldParser.new('GPSLatitude', '37.50233333 S')
 
-    _(p.value).must_be_close_to(-37.50233333)
+    assert_in_delta(-37.50233333, p.value)
   end
 
   it 'parses E GPS coords' do
     p = Exiftool::FieldParser.new('GPSLongitude', '122.47566667 E')
 
-    _(p.value).must_be_close_to(122.47566667)
+    assert_in_delta(122.47566667, p.value)
   end
 
   it 'parses W GPS coords' do
     p = Exiftool::FieldParser.new('GPSLongitude', '122.47566667 W')
 
-    _(p.value).must_be_close_to(-122.47566667)
+    assert_in_delta(-122.47566667, p.value)
   end
 
   it 'parses numerical only GPS coordinates' do
     p = Exiftool::FieldParser.new('GPSLongitude', -122.475666666667)
 
-    _(p.value).must_be_close_to(-122.475666666667)
+    assert_in_delta(-122.475666666667, p.value)
   end
 
   it 'parses track tags without reducing a fraction to lowest terms' do
     p = Exiftool::FieldParser.new('Track', '2/24')
 
-    _(p.value).must_equal('2/24')
+    assert_equal('2/24', p.value)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,8 +6,6 @@ SimpleCov.start do
 end
 
 require 'minitest/autorun'
-require 'minitest/unit'
-require 'minitest/great_expectations'
 require 'yaml'
 require 'exiftool'
 require 'simplecov-console'


### PR DESCRIPTION
- Using latest `minitest` gem
- Removed `minitest-great_expectations` from the development dependencies.
- Updated tests to use native Minitest assertions while keeping the existing `describe` and `it` blocks.
- Updated supported Ruby versions to Ruby 3.2 through 4.0.
- Added Ruby 4.0 to the GitHub Actions test matrix.