### PR TITLE
Improve missing exiftool test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ this if you've installed added the exiftool directory to the PATH of the shell t
 
 ## Change history
 
+### 1.4.1
+
+- Added test coverage for missing `exiftool` command handling.
+
 ### 1.4.0
 
 - Removed `minitest-great_expectations` from the development dependencies.

--- a/lib/exiftool/version.rb
+++ b/lib/exiftool/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Exiftool
-  VERSION = Gem::Version.new('1.4.0')
+  VERSION = Gem::Version.new('1.4.1')
 end

--- a/test/exiftool_test.rb
+++ b/test/exiftool_test.rb
@@ -48,6 +48,21 @@ describe Exiftool do
     assert_equal('foo/bar/exiftool', e.command)
   end
 
+  it 'returns empty version for missing exiftool command' do
+    e = Class.new(Exiftool)
+    e.command = 'no/such/exiftool'
+
+    assert_equal('', e.exiftool_version)
+    refute_predicate(e, :exiftool_installed?)
+  end
+
+  it 'raises ExiftoolNotInstalled for missing exiftool command' do
+    e = Class.new(Exiftool)
+    e.command = 'no/such/exiftool'
+
+    assert_raises(Exiftool::ExiftoolNotInstalled) { e.new('test/IMG_2452.jpg') }
+  end
+
   it 'raises NoSuchFile for missing files' do
     assert_raises(Exiftool::NoSuchFile) { Exiftool.new('no/such/file') }
   end


### PR DESCRIPTION
## Summary

- Add tests for missing `exiftool` command handling during version lookup and initialization.
- Bump the gem version to `1.4.1`.
- Document the coverage improvement in the README change history.

## Validation

- `bundle exec rake test` passes with 38 tests and 71 assertions.
- Coverage reports 100.00% line coverage.
- `bundle exec rake rubocop` passes with no offenses.